### PR TITLE
Bump log4j-core from 2.13.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <aspectj.version>1.9.5</aspectj.version>
         <testng.version>7.0.0</testng.version>
         <selenium.version>3.141.59</selenium.version>
-        <log4j-core.version>2.13.0</log4j-core.version>
+        <log4j-core.version>2.17.1</log4j-core.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <slf4j-simple.version>1.7.30</slf4j-simple.version>
         <allure-testng.version>2.13.1</allure-testng.version>


### PR DESCRIPTION
Bumps log4j-core from 2.13.0 to 2.17.1.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>